### PR TITLE
#31: Bug Fix

### DIFF
--- a/client/src/pages/bookmarks/Bookmarks.tsx
+++ b/client/src/pages/bookmarks/Bookmarks.tsx
@@ -226,7 +226,7 @@ const Bookmarks = () => {
 
         {!loading && bookmarks.length === 0 && !isSearching && <NoItems text="bookmarks" />}
 
-        {(bookmarks.length > 0 || isSearching) && (
+        {bookmarks.length > 0 && (
           <>
             <BookmarksGrid
               handleUpdateBookmark={handleUpdate}

--- a/client/src/pages/note/Notes.tsx
+++ b/client/src/pages/note/Notes.tsx
@@ -200,7 +200,7 @@ const Notes = () => {
 
         {!loading && notes.length === 0 && !isSearching && <NoItems text="notes" />}
 
-        {(notes.length > 0 || isSearching) && (
+        {notes.length > 0 && (
           <>
             <NotesGrid
               handleUpdateNote={handleUpdate}

--- a/client/src/pages/text-template/TextTemplates.tsx
+++ b/client/src/pages/text-template/TextTemplates.tsx
@@ -169,7 +169,7 @@ const TextTemplates = () => {
 
         {!loading && templates.length === 0 && !isSearching && <NoItems text="templates" />}
 
-        {(templates.length > 0 || isSearching) && (
+        {templates.length > 0 && (
           <>
             <TextTemplatesGrid
               templates={templates}


### PR DESCRIPTION
Searching Loader shown twice.

Fixes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-search behavior on Bookmarks, Notes, and Text Templates pages: grids no longer render during active searches with no results. Grids now appear only when items exist, reducing flicker and confusion. Existing loaders and empty states continue to provide feedback during searches and when no results are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->