### PR TITLE
Fix #57 : Refresh token rotation and comprehensive testing

### DIFF
--- a/client/src/api/client/private.client.ts
+++ b/client/src/api/client/private.client.ts
@@ -64,6 +64,9 @@ privateClient.interceptors.response.use(
 
           if (data.status === "success" && data.token) {
             localStorage.setItem(LocalStorageConstants.JWT_TOKEN, data.token);
+            if (data.refreshToken) {
+              localStorage.setItem(LocalStorageConstants.REFRESH_TOKEN, data.refreshToken);
+            }
             error.config.headers["Authorization"] = `Bearer ${data.token}`;
             return privateClient(error.config);
           }

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -195,6 +195,8 @@ export const refreshToken = catchAsync(async (req, res) => {
     if (!refreshToken) throw new AppError("Refresh token required", 400);
 
     const decoded = jsonwebtoken.verify(refreshToken, process.env.TOKEN_SECRET);
+    if (!decoded.data) throw new AppError("Invalid token payload", 401);
+
     const user = await userModel.findById(decoded.data);
     if (!user) throw new AppError("User not found", 404);
 

--- a/server/src/controllers/user.controller.js
+++ b/server/src/controllers/user.controller.js
@@ -198,11 +198,12 @@ export const refreshToken = catchAsync(async (req, res) => {
     const user = await userModel.findById(decoded.data);
     if (!user) throw new AppError("User not found", 404);
 
-    const { token: newToken } = generateTokens(user.id);
+    const { token: newToken, refreshToken: newRefreshToken } = generateTokens(user.id);
 
     res.status(200).json({
         status: "success",
         token: newToken,
+        refreshToken: newRefreshToken,
         message: "Token refreshed successfully.",
     });
 });

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,5 +1,8 @@
 import request from 'supertest';
 import app from '../app.js';
+import { jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+import mongoose from 'mongoose';
 
 
 describe('Auth Endpoints', () => {
@@ -174,6 +177,7 @@ describe('Auth Endpoints', () => {
 
             expect(res.statusCode).toEqual(200);
             expect(res.body.token).toBeDefined();
+            expect(res.body.refreshToken).toBeDefined();
         });
 
         it('should fail if refresh token is missing', async () => {
@@ -190,6 +194,108 @@ describe('Auth Endpoints', () => {
                 .send({ refreshToken: 'invalidtoken' });
 
             expect(res.statusCode).toEqual(401);
+        });
+
+        describe('Token Expiration & Rotation Scenarios', () => {
+
+            it('should fail if the refresh token has expired (e.g., after 7 days)', async () => {
+                // Generate a token that expired 1 second ago
+                const expiredToken = jwt.sign(
+                    { data: 'someuserid' },
+                    process.env.TOKEN_SECRET || 'testsecret',
+                    { expiresIn: '-1s' }
+                );
+
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken: expiredToken });
+
+                // Assuming error handler returns 401 for expired token
+                expect(res.statusCode).toEqual(401);
+                expect(res.body.message).toMatch(/token has expired/i);
+            });
+
+            it('should return a new refresh token with an extended expiration date (Token Rotation)', async () => {
+                // Wait 1 second so that the new token has a different 'iat' and 'exp'
+                await new Promise(resolve => setTimeout(resolve, 1000));
+
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken });
+
+                expect(res.statusCode).toEqual(200);
+                const newRefreshToken = res.body.refreshToken;
+                expect(newRefreshToken).toBeDefined();
+                
+                // Decode both to compare 'exp'
+                const decodedOld = jwt.decode(refreshToken);
+                const decodedNew = jwt.decode(newRefreshToken);
+
+                // The new token should have an expiration further in the future
+                expect(decodedNew.exp).toBeGreaterThan(decodedOld.exp);
+                // Also the tokens themselves should differ
+                expect(newRefreshToken).not.toEqual(refreshToken);
+            });
+            
+            it('should fail if refresh token is valid but the user no longer exists', async () => {
+                // Create a 7-day valid token for a completely fake user ID
+                const fakeId = new mongoose.Types.ObjectId().toString();
+                const fakeToken = jwt.sign(
+                    { data: fakeId },
+                    process.env.TOKEN_SECRET || 'testsecret',
+                    { expiresIn: '7d' }
+                );
+
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken: fakeToken });
+
+                expect(res.statusCode).toEqual(404);
+                expect(res.body.message).toMatch(/User not found/i);
+            });
+        });
+
+        describe('Security & Malformed Token Scenarios', () => {
+            it('should fail with 401 if the token signature is tampered (invalid secret)', async () => {
+                // Sign with a different secret
+                const tamperedToken = jwt.sign(
+                    { data: 'someuserid' },
+                    'wrong_secret_key',
+                    { expiresIn: '7d' }
+                );
+
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken: tamperedToken });
+
+                expect(res.statusCode).toEqual(401);
+                expect(res.body.message).toMatch(/invalid token/i); // Assuming global error handler catches it
+            });
+
+            it('should fail with 404/401 if the token payload is missing data', async () => {
+                // Sign a valid token but without the 'data' field
+                const emptyPayloadToken = jwt.sign(
+                    { },
+                    process.env.TOKEN_SECRET || 'testsecret',
+                    { expiresIn: '7d' }
+                );
+
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken: emptyPayloadToken });
+
+                // In controller: userModel.findById(undefined) might return 404 or throw CastError handled as 400/500
+                // Let's assert it's just not 200 success
+                expect(res.statusCode).not.toEqual(200);
+            });
+
+            it('should fail with 401 for completely malformed string', async () => {
+                const res = await request(app)
+                    .post('/api/v1/auth/refresh-token')
+                    .send({ refreshToken: 'header.payload' }); // Missing signature part
+
+                expect(res.statusCode).toEqual(401);
+            });
         });
     });
 

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,6 +1,5 @@
 import request from 'supertest';
 import app from '../app.js';
-import { jest } from '@jest/globals';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 
@@ -272,7 +271,7 @@ describe('Auth Endpoints', () => {
                 expect(res.body.message).toMatch(/invalid token/i); // Assuming global error handler catches it
             });
 
-            it('should fail with 404/401 if the token payload is missing data', async () => {
+            it('should fail with 401 if the token payload is missing data', async () => {
                 // Sign a valid token but without the 'data' field
                 const emptyPayloadToken = jwt.sign(
                     { },
@@ -284,9 +283,8 @@ describe('Auth Endpoints', () => {
                     .post('/api/v1/auth/refresh-token')
                     .send({ refreshToken: emptyPayloadToken });
 
-                // In controller: userModel.findById(undefined) might return 404 or throw CastError handled as 400/500
-                // Let's assert it's just not 200 success
-                expect(res.statusCode).not.toEqual(200);
+                expect(res.statusCode).toEqual(401);
+                expect(res.body.message).toMatch(/invalid token payload/i);
             });
 
             it('should fail with 401 for completely malformed string', async () => {


### PR DESCRIPTION
This PR fixes a bug (#57) where the backend was not returning the newly rotated refresh token to the client, leading to unexpected logouts exactly 7 days after the initial login.

Changes included:
- Backend now returns `refreshToken` alongside the access token.
- Client correctly saves the newly returned refresh token in `localStorage`.
- Added comprehensive tests for Token Expiration & Rotation scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Refreshing an expired access token now also provides a newly rotated refresh token.
  - The application automatically stores the updated refresh token for continued sessions.

- **Bug Fixes**
  - Improved handling of refresh-token rotation and credential renewal.

- **Tests**
  - Expanded coverage for expired, invalid, tampered, malformed, and incomplete refresh tokens.
  - Added validation for missing accounts and confirmed that rotated tokens are newly issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->